### PR TITLE
Add MVP implementation of cmakefmt

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,7 +20,7 @@ ci:
       - any-glob-to-any-file: .github/**
 repo:
   - changed-files:
-      - any-glob-to-any-file: codecov.yaml
+      - any-glob-to-any-file: .codecov.yaml
       - any-glob-to-any-file: .golangci-lint.yml
       - any-glob-to-any-file: .goreleaser.yaml
       - any-glob-to-any-file: .markdownlint.yaml
@@ -28,6 +28,19 @@ repo:
 docker:
   - changed-files:
       - any-glob-to-any-file: Dockerfile
+
+security:
+  - changed-files:
+      - any-glob-to-any-file: ".github/workflows/security.yml"
+      - any-glob-to-any-file: ".goreleaser.yml"
+  - head-branch: ["^security", "security"]
+
+code-quality:
+  - head-branch: ["^refactor", "refactor", "^cleanup", "cleanup"]
+
+chore:
+  - head-branch: ["^chore", "chore"]
+
 # Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
 feature:
   - head-branch: ["^feature", "feature"]

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,29 @@
+---
+name: Determine known CVEs through `govulncheck`
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Mondays at 0000
+    - cron: "0 0 * * 1"
+jobs:
+  check-for-vulnerabilities:
+    name: Check for vulnerabilities using `govulncheck`
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: donaldgifford/govulncheck-action@v1
+        with:
+          # NOTE that we want to produce the SARIF-formatted report, which can then be consumed by other tools ...
+          output-format: sarif
+          output-file: govulncheck.sarif
+
+      # ... such as the Code Scanning tab (https://github.com/oapi-codegen/oapi-codegen/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3Agovulncheck)
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ go.work.sum
 
 # Build directories
 build/
+bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,10 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
 
 archives:
   - id: default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+cmakefmt is a fast, opinionated CMake formatter written in Go. Single binary, zero external dependencies. Designed for editor integration (stdin/stdout mode) and CI checks (--check mode with exit codes).
+
+## Build & Development Commands
+
+```bash
+make build          # Build binary to bin/cmakefmt (injects version/commit via ldflags)
+make test           # Run all tests with race detector
+make lint           # Run golangci-lint (Uber Go Style config in .golangci.yml)
+make clean          # Remove bin/ directory
+make install        # Install binary to $GOPATH/bin
+make fmt            # Format testdata/ with cmakefmt (dogfooding)
+make check          # Check testdata/ formatting (dry run)
+```
+
+Run a single test:
+```bash
+go test -race -v ./internal/lexer/ -run TestTokenizeSimpleCommand
+```
+
+## Architecture
+
+The formatter uses a **Lexer → Parser → Rules → Formatter** pipeline:
+
+1. **Lexer** (`internal/lexer/`) — Tokenizes CMake source into a typed token stream. Handles all CMake constructs: quoted/unquoted/bracket arguments, line/bracket comments, and identifies commands by lookahead for `(`. Contains the keyword list (PUBLIC, PRIVATE, etc.) and block opener/closer detection (if/endif, foreach/endforeach, etc.).
+
+2. **Parser** (`internal/parser/`) — Recursive descent parser building an AST from the token stream. AST nodes: `File`, `CommandInvocation`, `Argument`, `Comment`, `BlankLine`, `BlockNode` (nested if/foreach/while/function/macro blocks with middles for else/elseif).
+
+3. **Rules** (`internal/formatter/rules/`) — Extensible rule system using a registry pattern (rules self-register via `init()`). Each rule implements `Name()`, `Description()`, and `Apply(node, config)` to transform the AST in place. Current rules: `command_case`, `keyword_case`.
+
+4. **Formatter** (`internal/formatter/`) — Emits formatted source from the AST. Handles indentation, single-line vs multi-line decisions based on line length, dangling parentheses, trailing whitespace removal, blank line limiting, and line ending normalization.
+
+5. **CLI** (`cmd/cmakefmt/main.go`) — Entry point handling three modes: stdin/stdout (no args, for editors), file arguments, and directory recursion. Supports `--check`, `--diff`, `-i` (in-place), `--config`, and rule override flags.
+
+## Configuration
+
+Formatter config is defined in `internal/config/config.go`. Config files (`.cmakefmt`) are discovered by walking up from the working directory. Supports JSON and simple YAML-like key-value format. Key defaults: 80 char line length, 2-space indent, lowercase commands, uppercase keywords, dangling parentheses enabled.
+
+## Code Style
+
+- Follows **Uber Go Style Guide** — enforced by golangci-lint with strict settings (gocyclo max 15, funlen max 100 lines, gofumpt formatting)
+- Zero external Go dependencies (stdlib only)
+- Go 1.25.7

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+BINARY := cmakefmt
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)"
+
+.PHONY: all build test lint clean install
+
+all: build
+
+build:
+	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/cmakefmt
+
+test:
+	go test -v -race ./...
+
+lint:
+	golangci-lint run ./...
+
+clean:
+	rm -rf bin/
+
+install:
+	go install $(LDFLAGS) ./cmd/cmakefmt
+
+# Format all CMake files in the project (dogfooding).
+fmt:
+	bin/$(BINARY) -i testdata/
+
+# Check formatting (for CI).
+check:
+	bin/$(BINARY) -check testdata/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,195 @@
 # cmakefmt
 
-<no value>
+A fast, opinionated CMake formatter written in Go. Single binary, zero
+dependencies.
 
-## Getting Started
+Designed to work as a format-on-save tool with editors (via `conform.nvim`,
+etc.) and as a CI check.
 
-TODO: Add getting started instructions.
+## Installation
+
+```bash
+go install github.com/yourusername/cmakefmt/cmd/cmakefmt@latest
+```
+
+Or download a binary from
+[Releases](https://github.com/yourusername/cmakefmt/releases).
+
+## Usage
+
+```bash
+# Format a file (prints to stdout)
+cmakefmt CMakeLists.txt
+
+# Format in-place
+cmakefmt -i CMakeLists.txt
+
+# Format all CMake files in a directory
+cmakefmt -i .
+
+# Read from stdin, write to stdout (for editors)
+cmakefmt < CMakeLists.txt
+
+# Check formatting (exits 1 if changes needed — for CI)
+cmakefmt -check .
+
+# Check with diff output
+cmakefmt -check -diff .
+
+# List available rules
+cmakefmt -list-rules
+```
+
+### CI Usage
+
+```yaml
+# GitHub Actions
+- name: Check CMake formatting
+  run: cmakefmt -check .
+```
+
+## Configuration
+
+Create a `.cmakefmt` file in your project root:
+
+```yaml
+# Maximum line length before wrapping arguments.
+line_length: 80
+
+# Number of spaces per indentation level.
+indent: 2
+
+# Command name casing: "lower", "upper", or "unchanged".
+command_case: lower
+
+# Keyword argument casing: "upper", "lower", or "unchanged".
+keyword_case: upper
+
+# Put closing ')' on its own line when arguments span multiple lines.
+dangling_parenthesis: true
+
+# Ensure the file ends with a newline.
+trailing_newline: true
+
+# Remove trailing whitespace from lines.
+trim_trailing_whitespace: true
+
+# Maximum consecutive blank lines to preserve.
+max_blank_lines: 2
+
+# Line ending style: "lf", "crlf", or "auto".
+line_ending: lf
+
+# Per-rule configuration.
+# rules:
+#   command_case:
+#     enabled: false
+```
+
+The config file is discovered by walking up from the working directory, similar
+to `.editorconfig` or `.yamlfmt`.
+
+## Editor Integration
+
+### Neovim (conform.nvim + LazyVim)
+
+```lua
+-- In your LazyVim config (e.g., lua/plugins/formatting.lua)
+return {
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters_by_ft = {
+        cmake = { "cmakefmt" },
+      },
+      formatters = {
+        cmakefmt = {
+          command = "cmakefmt",
+          stdin = true,
+        },
+      },
+    },
+  },
+}
+```
+
+This works because `cmakefmt` reads from stdin and writes to stdout when invoked
+with no file arguments — exactly the contract `conform.nvim` expects.
+
+### VS Code
+
+Use the "Run on Save" extension with:
+
+```json
+{
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "CMakeLists\\.txt$|\\.cmake$",
+        "cmd": "cmakefmt -i ${file}"
+      }
+    ]
+  }
+}
+```
+
+## Adding New Rules
+
+Rules follow a simple interface pattern inspired by
+[checkmake](https://github.com/checkmake/checkmake):
+
+```go
+// In internal/formatter/rules/my_rule.go
+package rules
+
+func init() {
+    Register(&MyRule{})
+}
+
+type MyRule struct{}
+
+func (r *MyRule) Name() string        { return "my_rule" }
+func (r *MyRule) Description() string { return "Does something useful" }
+func (r *MyRule) Apply(node parser.Node, cfg *config.Config) error {
+    // Transform the AST node.
+    return nil
+}
+```
+
+The rule is automatically registered via `init()` and can be enabled/disabled
+through the config file.
+
+## Architecture
+
+```
+cmakefmt/
+├── cmd/cmakefmt/          # CLI entrypoint
+├── internal/
+│   ├── config/            # Config file loading (.cmakefmt)
+│   ├── lexer/             # CMake tokenizer
+│   ├── parser/            # CMake AST builder
+│   └── formatter/         # Formatting engine
+│       └── rules/         # Individual formatting rules (add new rules here)
+├── testdata/              # Test fixtures
+├── .cmakefmt              # Example config
+├── .goreleaser.yaml       # Release automation
+└── Makefile
+```
+
+The pipeline is: **Source → Lexer → Tokens → Parser → AST → Rules → Formatter →
+Output**
+
+## Acknowledgments
+
+- [yamlfmt](https://github.com/google/yamlfmt) — Architecture inspiration
+  (config, extensible formatters, CI mode)
+- [checkmake](https://github.com/checkmake/checkmake) — Rule registration
+  pattern
+- [gersemi](https://github.com/BlankSpruce/gersemi) — CMake formatting
+  heuristics reference
+- [cmake-format](https://github.com/cheshirekow/cmake_format) — Original CMake
+  formatter
+
+## License
+
+MIT

--- a/cmd/cmakefmt/main.go
+++ b/cmd/cmakefmt/main.go
@@ -1,2 +1,305 @@
 // Package main is the entry point for the cmakefmt
 package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/donaldgifford/cmakefmt/internal/config"
+	"github.com/donaldgifford/cmakefmt/internal/formatter"
+	"github.com/donaldgifford/cmakefmt/internal/formatter/rules"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+)
+
+func main() {
+	// Flags.
+	checkFlag := flag.Bool("check", false, "Check if files are formatted (exit 1 if not)")
+	diffFlag := flag.Bool("diff", false, "Show diff of formatting changes")
+	inPlaceFlag := flag.Bool("i", false, "Format files in-place")
+	configPath := flag.String("config", "", "Path to config file (default: search for .cmakefmt)")
+	versionFlag := flag.Bool("version", false, "Print version and exit")
+	listRulesFlag := flag.Bool("list-rules", false, "List all available formatting rules")
+
+	// Config overrides.
+	lineLength := flag.Int("line-length", 0, "Override max line length")
+	indent := flag.Int("indent", 0, "Override indentation width")
+	commandCase := flag.String("command-case", "", "Override command casing (lower, upper, unchanged)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: cmakefmt [flags] [files...]\n\n")
+		fmt.Fprintf(os.Stderr, "A formatter for CMake files.\n\n")
+		fmt.Fprintf(os.Stderr, "With no file arguments, reads from stdin and writes to stdout.\n")
+		fmt.Fprintf(os.Stderr, "This mode is designed for use with editor integrations like conform.nvim.\n\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  cmakefmt CMakeLists.txt              # Print formatted output to stdout\n")
+		fmt.Fprintf(os.Stderr, "  cmakefmt -i CMakeLists.txt           # Format in-place\n")
+		fmt.Fprintf(os.Stderr, "  cmakefmt -check .                    # Check all CMake files (for CI)\n")
+		fmt.Fprintf(os.Stderr, "  cmakefmt < CMakeLists.txt            # Read from stdin (for editors)\n")
+	}
+
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Printf("cmakefmt %s (%s)\n", version, commit)
+		os.Exit(0)
+	}
+
+	if *listRulesFlag {
+		listRules()
+		os.Exit(0)
+	}
+
+	// Load config.
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fatal("Error loading config: %v", err)
+	}
+
+	// Apply CLI overrides.
+	if *lineLength > 0 {
+		cfg.LineLength = *lineLength
+	}
+	if *indent > 0 {
+		cfg.Indent = *indent
+	}
+	if *commandCase != "" {
+		cfg.CommandCase = *commandCase
+	}
+
+	fmtr := formatter.New(cfg)
+
+	args := flag.Args()
+
+	// No file arguments: stdin/stdout mode (for conform.nvim and editors).
+	if len(args) == 0 {
+		if err := formatStdin(fmtr); err != nil {
+			fatal("Error: %v", err)
+		}
+		return
+	}
+
+	// Collect files to format.
+	files, err := collectFiles(args)
+	if err != nil {
+		fatal("Error collecting files: %v", err)
+	}
+
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "No CMake files found")
+		os.Exit(0)
+	}
+
+	// Process files.
+	hasChanges := false
+	hasErrors := false
+
+	for _, file := range files {
+		input, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", file, err)
+			hasErrors = true
+			continue
+		}
+
+		output, err := fmtr.Format(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting %s: %v\n", file, err)
+			hasErrors = true
+			continue
+		}
+
+		if string(input) == string(output) {
+			continue
+		}
+
+		hasChanges = true
+
+		if *checkFlag {
+			fmt.Fprintf(os.Stderr, "%s: would be reformatted\n", file)
+			if *diffFlag {
+				printDiff(file, string(input), string(output))
+			}
+			continue
+		}
+
+		if *diffFlag {
+			printDiff(file, string(input), string(output))
+			continue
+		}
+
+		if *inPlaceFlag {
+			if err := os.WriteFile(file, output, 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing %s: %v\n", file, err)
+				hasErrors = true
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "Formatted %s\n", file)
+		} else {
+			os.Stdout.Write(output)
+		}
+	}
+
+	if hasErrors {
+		os.Exit(2)
+	}
+	if *checkFlag && hasChanges {
+		os.Exit(1)
+	}
+}
+
+func formatStdin(fmtr *formatter.Formatter) error {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("reading stdin: %w", err)
+	}
+
+	output, err := fmtr.Format(input)
+	if err != nil {
+		return fmt.Errorf("formatting: %w", err)
+	}
+
+	_, err = os.Stdout.Write(output)
+	return err
+}
+
+func loadConfig(path string) (*config.Config, error) {
+	if path != "" {
+		return config.Load(path)
+	}
+
+	// Search upward from cwd.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return config.DefaultConfig(), nil
+	}
+
+	found := config.FindConfigFile(cwd)
+	if found != "" {
+		return config.Load(found)
+	}
+
+	return config.DefaultConfig(), nil
+}
+
+func collectFiles(args []string) ([]string, error) {
+	var files []string
+	for _, arg := range args {
+		info, err := os.Stat(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		if !info.IsDir() {
+			files = append(files, arg)
+			continue
+		}
+
+		// Walk directory for CMake files.
+		err = filepath.Walk(arg, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				// Skip hidden dirs and build dirs.
+				base := filepath.Base(path)
+				if strings.HasPrefix(base, ".") || base == "build" || base == "node_modules" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if isCMakeFile(path) {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+func isCMakeFile(path string) bool {
+	base := filepath.Base(path)
+	if base == "CMakeLists.txt" {
+		return true
+	}
+	ext := filepath.Ext(path)
+	return ext == ".cmake"
+}
+
+func printDiff(filename, original, formatted string) {
+	origLines := strings.Split(original, "\n")
+	fmtLines := strings.Split(formatted, "\n")
+
+	fmt.Fprintf(os.Stderr, "--- %s (original)\n", filename)
+	fmt.Fprintf(os.Stderr, "+++ %s (formatted)\n", filename)
+
+	// Simple unified-ish diff output.
+	maxLines := len(origLines)
+	if len(fmtLines) > maxLines {
+		maxLines = len(fmtLines)
+	}
+
+	for i := range maxLines {
+		var origLine, fmtLine string
+		if i < len(origLines) {
+			origLine = origLines[i]
+		}
+		if i < len(fmtLines) {
+			fmtLine = fmtLines[i]
+		}
+
+		if origLine != fmtLine {
+			if i < len(origLines) {
+				fmt.Fprintf(os.Stderr, "-%s\n", origLine)
+			}
+			if i < len(fmtLines) {
+				fmt.Fprintf(os.Stderr, "+%s\n", fmtLine)
+			}
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+}
+
+func listRules() {
+	// Import to ensure init() runs.
+	allRules := getAllRules()
+	fmt.Println("Available formatting rules:")
+	fmt.Println()
+	for _, r := range allRules {
+		fmt.Printf("  %-25s %s\n", r.name, r.description)
+	}
+}
+
+type ruleInfo struct {
+	name        string
+	description string
+}
+
+func getAllRules() []ruleInfo {
+	// We reference the rules package directly.
+	var infos []ruleInfo
+	for _, r := range rules.All() {
+		infos = append(infos, ruleInfo{
+			name:        r.Name(),
+			description: r.Description(),
+		})
+	}
+	return infos
+}
+
+func fatal(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/donaldgifford/cmakefmt
+
+go 1.25.7

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,227 @@
+package config
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultConfigFile is the default config file name.
+	DefaultConfigFile = ".cmakefmt"
+)
+
+// Config holds all formatting configuration.
+type Config struct {
+	// LineLength is the maximum line length before wrapping.
+	LineLength int `json:"line_length"`
+	// Indent is the number of spaces per indentation level.
+	Indent int `json:"indent"`
+	// TabSize is the tab width (used if UseTabs is true).
+	TabSize int `json:"tab_size"`
+	// UseTabs uses tabs instead of spaces for indentation.
+	UseTabs bool `json:"use_tabs"`
+	// CommandCase controls the casing of command names.
+	// Values: "lower", "upper", "unchanged".
+	CommandCase string `json:"command_case"`
+	// KeywordCase controls the casing of keyword arguments.
+	// Values: "upper", "lower", "unchanged".
+	KeywordCase string `json:"keyword_case"`
+	// DanglingParenthesis puts the closing ')' on its own line
+	// when arguments span multiple lines.
+	DanglingParenthesis bool `json:"dangling_parenthesis"`
+	// TrailingNewline ensures the file ends with a newline.
+	TrailingNewline bool `json:"trailing_newline"`
+	// TrimTrailingWhitespace removes trailing whitespace from lines.
+	TrimTrailingWhitespace bool `json:"trim_trailing_whitespace"`
+	// MaxBlankLines is the maximum number of consecutive blank lines to keep.
+	MaxBlankLines int `json:"max_blank_lines"`
+	// SpaceBeforeParen inserts a space before '(' in command invocations.
+	SpaceBeforeParen bool `json:"space_before_paren"`
+	// LineEnding controls line ending style: "lf", "crlf", or "auto".
+	LineEnding string `json:"line_ending"`
+
+	// Rules enables or disables specific formatting rules.
+	Rules map[string]RuleConfig `json:"rules"`
+}
+
+// RuleConfig holds per-rule configuration options.
+type RuleConfig struct {
+	Enabled *bool                  `json:"enabled"`
+	Options map[string]interface{} `json:"options"`
+}
+
+// IsEnabled returns whether a rule is enabled (default: true).
+func (rc RuleConfig) IsEnabled() bool {
+	if rc.Enabled == nil {
+		return true
+	}
+	return *rc.Enabled
+}
+
+// DefaultConfig returns the default configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		LineLength:             80,
+		Indent:                 2,
+		TabSize:                4,
+		UseTabs:                false,
+		CommandCase:            "lower",
+		KeywordCase:            "upper",
+		DanglingParenthesis:    true,
+		TrailingNewline:        true,
+		TrimTrailingWhitespace: true,
+		MaxBlankLines:          2,
+		SpaceBeforeParen:       false,
+		LineEnding:             "lf",
+		Rules:                  make(map[string]RuleConfig),
+	}
+}
+
+// Load reads configuration from a file. Supports both JSON (.json) and
+// a simple YAML-like format (.cmakefmt). If the file doesn't exist, returns defaults.
+func Load(path string) (*Config, error) {
+	cfg := DefaultConfig()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, err
+	}
+
+	content := strings.TrimSpace(string(data))
+
+	// Try JSON first.
+	if strings.HasPrefix(content, "{") {
+		if err := json.Unmarshal(data, cfg); err != nil {
+			return nil, fmt.Errorf("parsing config as JSON: %w", err)
+		}
+		return cfg, nil
+	}
+
+	// Otherwise, parse as simple YAML-like key: value format.
+	if err := parseSimpleConfig(content, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// parseSimpleConfig parses a flat YAML-like config file.
+// Supports: key: value lines, comments (#), and blank lines.
+// This avoids requiring an external YAML dependency.
+func parseSimpleConfig(content string, cfg *Config) error {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Skip nested sections (rules: etc.) for now.
+		if !strings.Contains(line, ":") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		// Skip if value is empty (section header like "rules:").
+		if value == "" {
+			continue
+		}
+
+		switch key {
+		case "line_length":
+			if v, err := strconv.Atoi(value); err == nil {
+				cfg.LineLength = v
+			}
+		case "indent":
+			if v, err := strconv.Atoi(value); err == nil {
+				cfg.Indent = v
+			}
+		case "tab_size":
+			if v, err := strconv.Atoi(value); err == nil {
+				cfg.TabSize = v
+			}
+		case "use_tabs":
+			cfg.UseTabs = parseBool(value)
+		case "command_case":
+			cfg.CommandCase = value
+		case "keyword_case":
+			cfg.KeywordCase = value
+		case "dangling_parenthesis":
+			cfg.DanglingParenthesis = parseBool(value)
+		case "trailing_newline":
+			cfg.TrailingNewline = parseBool(value)
+		case "trim_trailing_whitespace":
+			cfg.TrimTrailingWhitespace = parseBool(value)
+		case "max_blank_lines":
+			if v, err := strconv.Atoi(value); err == nil {
+				cfg.MaxBlankLines = v
+			}
+		case "space_before_paren":
+			cfg.SpaceBeforeParen = parseBool(value)
+		case "line_ending":
+			cfg.LineEnding = value
+		}
+	}
+
+	return scanner.Err()
+}
+
+func parseBool(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return s == "true" || s == "yes" || s == "1"
+}
+
+// FindConfigFile searches for a config file by walking up from the given
+// directory. Returns the path to the config file, or empty string if not found.
+func FindConfigFile(startDir string) string {
+	dir := startDir
+	for {
+		candidate := filepath.Join(dir, DefaultConfigFile)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// Merge applies non-zero values from the override config onto the base config.
+func Merge(base, override *Config) *Config {
+	result := *base
+	if override.LineLength != 0 {
+		result.LineLength = override.LineLength
+	}
+	if override.Indent != 0 {
+		result.Indent = override.Indent
+	}
+	if override.CommandCase != "" {
+		result.CommandCase = override.CommandCase
+	}
+	if override.KeywordCase != "" {
+		result.KeywordCase = override.KeywordCase
+	}
+	return &result
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,0 +1,318 @@
+package formatter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/donaldgifford/cmakefmt/internal/config"
+	"github.com/donaldgifford/cmakefmt/internal/formatter/rules"
+	"github.com/donaldgifford/cmakefmt/internal/lexer"
+	"github.com/donaldgifford/cmakefmt/internal/parser"
+)
+
+// Formatter formats CMake source code.
+type Formatter struct {
+	Config *config.Config
+}
+
+// New creates a new Formatter with the given configuration.
+func New(cfg *config.Config) *Formatter {
+	return &Formatter{Config: cfg}
+}
+
+// Format takes CMake source and returns formatted output.
+func (f *Formatter) Format(input []byte) ([]byte, error) {
+	// Tokenize.
+	lex := lexer.New(string(input))
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		return nil, fmt.Errorf("lexer error: %w", err)
+	}
+
+	// Parse.
+	p := parser.New(tokens)
+	file, err := p.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("parser error: %w", err)
+	}
+
+	// Apply rules.
+	enabledRules := rules.EnabledRules(f.Config)
+	for _, rule := range enabledRules {
+		if err := rule.Apply(file, f.Config); err != nil {
+			return nil, fmt.Errorf("rule %q error: %w", rule.Name(), err)
+		}
+	}
+
+	// Emit formatted output.
+	var buf strings.Builder
+	f.emitFile(&buf, file, 0)
+
+	result := buf.String()
+
+	// Apply trailing newline.
+	if f.Config.TrailingNewline && !strings.HasSuffix(result, "\n") {
+		result += f.newline()
+	}
+
+	// Apply line ending normalization.
+	result = f.normalizeLineEndings(result)
+
+	// Apply trailing whitespace removal.
+	if f.Config.TrimTrailingWhitespace {
+		result = trimTrailingWhitespace(result)
+	}
+
+	return []byte(result), nil
+}
+
+func (f *Formatter) emitFile(buf *strings.Builder, file *parser.File, depth int) {
+	prevWasBlank := false
+	for _, el := range file.Elements {
+		switch n := el.(type) {
+		case *parser.CommandInvocation:
+			prevWasBlank = false
+			f.emitCommand(buf, n, depth)
+			buf.WriteString(f.newline())
+		case *parser.Comment:
+			prevWasBlank = false
+			f.emitIndent(buf, depth)
+			buf.WriteString(n.Value)
+			buf.WriteString(f.newline())
+		case *parser.BlankLine:
+			count := n.Count
+			if count > f.Config.MaxBlankLines {
+				count = f.Config.MaxBlankLines
+			}
+			if !prevWasBlank {
+				for range count {
+					buf.WriteString(f.newline())
+				}
+				prevWasBlank = true
+			}
+		case *parser.BlockNode:
+			prevWasBlank = false
+			f.emitBlock(buf, n, depth)
+		}
+	}
+}
+
+func (f *Formatter) emitBlock(buf *strings.Builder, block *parser.BlockNode, depth int) {
+	// Emit opener.
+	if block.Opener != nil {
+		f.emitCommand(buf, block.Opener, depth)
+		buf.WriteString(f.newline())
+	}
+
+	// Emit body (indented).
+	f.emitElements(buf, block.Body, depth+1)
+
+	// Emit middles (else/elseif).
+	for _, mid := range block.Middles {
+		if mid.Command != nil {
+			f.emitCommand(buf, mid.Command, depth)
+			buf.WriteString(f.newline())
+		}
+		f.emitElements(buf, mid.Body, depth+1)
+	}
+
+	// Emit closer.
+	if block.Closer != nil {
+		f.emitCommand(buf, block.Closer, depth)
+		buf.WriteString(f.newline())
+	}
+}
+
+func (f *Formatter) emitElements(buf *strings.Builder, elements []parser.Node, depth int) {
+	prevWasBlank := false
+	for _, el := range elements {
+		switch n := el.(type) {
+		case *parser.CommandInvocation:
+			prevWasBlank = false
+			f.emitCommand(buf, n, depth)
+			buf.WriteString(f.newline())
+		case *parser.Comment:
+			prevWasBlank = false
+			f.emitIndent(buf, depth)
+			buf.WriteString(n.Value)
+			buf.WriteString(f.newline())
+		case *parser.BlankLine:
+			count := n.Count
+			if count > f.Config.MaxBlankLines {
+				count = f.Config.MaxBlankLines
+			}
+			if !prevWasBlank {
+				for range count {
+					buf.WriteString(f.newline())
+				}
+				prevWasBlank = true
+			}
+		case *parser.BlockNode:
+			prevWasBlank = false
+			f.emitBlock(buf, n, depth)
+		}
+	}
+}
+
+func (f *Formatter) emitCommand(buf *strings.Builder, cmd *parser.CommandInvocation, depth int) {
+	f.emitIndent(buf, depth)
+	buf.WriteString(cmd.Name)
+
+	if f.Config.SpaceBeforeParen {
+		buf.WriteString(" ")
+	}
+	buf.WriteString("(")
+
+	args := filterNonCommentArgs(cmd.Arguments)
+	commentArgs := filterCommentArgs(cmd.Arguments)
+
+	if len(args) == 0 {
+		buf.WriteString(")")
+		f.emitTrailingComment(buf, cmd)
+		return
+	}
+
+	// Determine if we need to wrap.
+	singleLine := f.formatArgsSingleLine(args)
+	indentStr := f.indentString(depth)
+	commandWidth := len(indentStr) + len(cmd.Name) + 1 + len(singleLine) + 1 // +1 for ( and )
+
+	if commandWidth <= f.Config.LineLength && len(commentArgs) == 0 {
+		// Single line.
+		buf.WriteString(singleLine)
+		buf.WriteString(")")
+	} else {
+		// Multi-line.
+		f.emitArgsMultiLine(buf, cmd.Arguments, depth)
+		if f.Config.DanglingParenthesis {
+			buf.WriteString(f.newline())
+			f.emitIndent(buf, depth)
+			buf.WriteString(")")
+		} else {
+			buf.WriteString(")")
+		}
+	}
+
+	f.emitTrailingComment(buf, cmd)
+}
+
+func (f *Formatter) emitArgsMultiLine(buf *strings.Builder, args []parser.Argument, depth int) {
+	for _, arg := range args {
+		buf.WriteString(f.newline())
+		f.emitIndent(buf, depth+1)
+		if arg.Token.Type == lexer.TokenLineComment {
+			buf.WriteString(arg.Token.Value)
+		} else if len(arg.Children) > 0 {
+			// Parenthesized group — flatten for now.
+			buf.WriteString("(")
+			for i, child := range arg.Children {
+				if i > 0 {
+					buf.WriteString(" ")
+				}
+				buf.WriteString(child.Token.Value)
+			}
+			buf.WriteString(")")
+		} else {
+			buf.WriteString(arg.Token.Value)
+		}
+	}
+}
+
+func (f *Formatter) formatArgsSingleLine(args []parser.Argument) string {
+	var parts []string
+	for _, arg := range args {
+		if len(arg.Children) > 0 {
+			var inner []string
+			for _, child := range arg.Children {
+				inner = append(inner, child.Token.Value)
+			}
+			parts = append(parts, "("+strings.Join(inner, " ")+")")
+		} else {
+			parts = append(parts, arg.Token.Value)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func (f *Formatter) emitTrailingComment(buf *strings.Builder, cmd *parser.CommandInvocation) {
+	if cmd.TrailingComment != "" {
+		buf.WriteString(" ")
+		buf.WriteString(cmd.TrailingComment)
+	}
+}
+
+func (f *Formatter) emitIndent(buf *strings.Builder, depth int) {
+	if depth <= 0 {
+		return
+	}
+	if f.Config.UseTabs {
+		for range depth {
+			buf.WriteByte('\t')
+		}
+	} else {
+		for range depth * f.Config.Indent {
+			buf.WriteByte(' ')
+		}
+	}
+}
+
+func (f *Formatter) indentString(depth int) string {
+	if depth <= 0 {
+		return ""
+	}
+	if f.Config.UseTabs {
+		return strings.Repeat("\t", depth)
+	}
+	return strings.Repeat(" ", depth*f.Config.Indent)
+}
+
+func (f *Formatter) newline() string {
+	switch f.Config.LineEnding {
+	case "crlf":
+		return "\r\n"
+	default:
+		return "\n"
+	}
+}
+
+func (f *Formatter) normalizeLineEndings(s string) string {
+	switch f.Config.LineEnding {
+	case "crlf":
+		// First normalize to LF, then convert to CRLF.
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		s = strings.ReplaceAll(s, "\r", "\n")
+		s = strings.ReplaceAll(s, "\n", "\r\n")
+	case "lf":
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		s = strings.ReplaceAll(s, "\r", "\n")
+	}
+	return s
+}
+
+func trimTrailingWhitespace(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func filterNonCommentArgs(args []parser.Argument) []parser.Argument {
+	var result []parser.Argument
+	for _, a := range args {
+		if a.Token.Type != lexer.TokenLineComment {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+func filterCommentArgs(args []parser.Argument) []parser.Argument {
+	var result []parser.Argument
+	for _, a := range args {
+		if a.Token.Type == lexer.TokenLineComment {
+			result = append(result, a)
+		}
+	}
+	return result
+}

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,0 +1,139 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/donaldgifford/cmakefmt/internal/config"
+
+	// Import rules to trigger init() registration.
+	_ "github.com/donaldgifford/cmakefmt/internal/formatter/rules"
+)
+
+func TestFormatSimpleCommand(t *testing.T) {
+	input := `SET(FOO "bar")`
+	cfg := config.DefaultConfig()
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "set(") {
+		t.Errorf("expected lowercase command, got:\n%s", result)
+	}
+}
+
+func TestFormatPreservesComments(t *testing.T) {
+	input := "# This is a comment\nset(FOO bar)\n"
+	cfg := config.DefaultConfig()
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "# This is a comment") {
+		t.Errorf("expected comment to be preserved, got:\n%s", result)
+	}
+}
+
+func TestFormatBlockIndentation(t *testing.T) {
+	input := `if(FOO)
+set(BAR baz)
+endif()
+`
+	cfg := config.DefaultConfig()
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	lines := strings.Split(result, "\n")
+
+	// The set() command should be indented.
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "set(") {
+			found = true
+			if !strings.HasPrefix(line, "  ") {
+				t.Errorf("expected indented set(), got: %q", line)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("set() command not found in output:\n%s", result)
+	}
+}
+
+func TestFormatUpperCommandCase(t *testing.T) {
+	input := `set(FOO "bar")`
+	cfg := config.DefaultConfig()
+	cfg.CommandCase = "upper"
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "SET(") {
+		t.Errorf("expected uppercase command, got:\n%s", result)
+	}
+}
+
+func TestFormatTrailingNewline(t *testing.T) {
+	input := `set(FOO bar)`
+	cfg := config.DefaultConfig()
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.HasSuffix(result, "\n") {
+		t.Error("expected trailing newline")
+	}
+}
+
+func TestFormatKeywordCase(t *testing.T) {
+	input := `target_link_libraries(mylib public fmt::fmt)`
+	cfg := config.DefaultConfig()
+	cfg.KeywordCase = "upper"
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	result := string(output)
+	if !strings.Contains(result, "PUBLIC") {
+		t.Errorf("expected uppercase PUBLIC keyword, got:\n%s", result)
+	}
+}
+
+func TestCheckModeDetectsChanges(t *testing.T) {
+	input := `SET(FOO "bar")`
+	cfg := config.DefaultConfig()
+	fmtr := New(cfg)
+
+	output, err := fmtr.Format([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(output) == input {
+		t.Error("expected formatting changes, got identical output")
+	}
+}

--- a/internal/formatter/rules/command_case.go
+++ b/internal/formatter/rules/command_case.go
@@ -1,0 +1,68 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/donaldgifford/cmakefmt/internal/config"
+	"github.com/donaldgifford/cmakefmt/internal/parser"
+)
+
+func init() {
+	Register(&CommandCaseRule{})
+}
+
+// CommandCaseRule normalizes command name casing (e.g., SET -> set).
+type CommandCaseRule struct{}
+
+func (r *CommandCaseRule) Name() string        { return "command_case" }
+func (r *CommandCaseRule) Description() string  { return "Normalize command name casing" }
+
+func (r *CommandCaseRule) Apply(node parser.Node, cfg *config.Config) error {
+	switch n := node.(type) {
+	case *parser.File:
+		for _, el := range n.Elements {
+			if err := r.Apply(el, cfg); err != nil {
+				return err
+			}
+		}
+	case *parser.CommandInvocation:
+		n.Name = applyCase(n.Name, cfg.CommandCase)
+	case *parser.BlockNode:
+		if n.Opener != nil {
+			n.Opener.Name = applyCase(n.Opener.Name, cfg.CommandCase)
+			if err := r.Apply(n.Opener, cfg); err != nil {
+				return err
+			}
+		}
+		for _, el := range n.Body {
+			if err := r.Apply(el, cfg); err != nil {
+				return err
+			}
+		}
+		for _, mid := range n.Middles {
+			if mid.Command != nil {
+				mid.Command.Name = applyCase(mid.Command.Name, cfg.CommandCase)
+			}
+			for _, el := range mid.Body {
+				if err := r.Apply(el, cfg); err != nil {
+					return err
+				}
+			}
+		}
+		if n.Closer != nil {
+			n.Closer.Name = applyCase(n.Closer.Name, cfg.CommandCase)
+		}
+	}
+	return nil
+}
+
+func applyCase(s, caseStyle string) string {
+	switch caseStyle {
+	case "lower":
+		return strings.ToLower(s)
+	case "upper":
+		return strings.ToUpper(s)
+	default:
+		return s
+	}
+}

--- a/internal/formatter/rules/keyword_case.go
+++ b/internal/formatter/rules/keyword_case.go
@@ -1,0 +1,84 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/donaldgifford/cmakefmt/internal/config"
+	"github.com/donaldgifford/cmakefmt/internal/lexer"
+	"github.com/donaldgifford/cmakefmt/internal/parser"
+)
+
+func init() {
+	Register(&KeywordCaseRule{})
+}
+
+// KeywordCaseRule normalizes keyword argument casing (e.g., public -> PUBLIC).
+type KeywordCaseRule struct{}
+
+func (r *KeywordCaseRule) Name() string        { return "keyword_case" }
+func (r *KeywordCaseRule) Description() string  { return "Normalize keyword argument casing" }
+
+func (r *KeywordCaseRule) Apply(node parser.Node, cfg *config.Config) error {
+	switch n := node.(type) {
+	case *parser.File:
+		for _, el := range n.Elements {
+			if err := r.Apply(el, cfg); err != nil {
+				return err
+			}
+		}
+	case *parser.CommandInvocation:
+		for i, arg := range n.Arguments {
+			if arg.Token.Type == lexer.TokenUnquotedArg && lexer.IsKeyword(arg.Token.Value) {
+				n.Arguments[i].Token.Value = applyCase(arg.Token.Value, cfg.KeywordCase)
+			}
+		}
+	case *parser.BlockNode:
+		if n.Opener != nil {
+			if err := r.Apply(n.Opener, cfg); err != nil {
+				return err
+			}
+		}
+		for _, el := range n.Body {
+			if err := r.Apply(el, cfg); err != nil {
+				return err
+			}
+		}
+		for _, mid := range n.Middles {
+			if mid.Command != nil {
+				if err := r.Apply(mid.Command, cfg); err != nil {
+					return err
+				}
+			}
+			for _, el := range mid.Body {
+				if err := r.Apply(el, cfg); err != nil {
+					return err
+				}
+			}
+		}
+		if n.Closer != nil {
+			if err := r.Apply(n.Closer, cfg); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// isKeywordLike checks if a string looks like a CMake keyword
+// (all uppercase letters and underscores, or a known keyword).
+func isKeywordLike(s string) bool {
+	if lexer.IsKeyword(s) {
+		return true
+	}
+	// Heuristic: all uppercase letters/digits/underscores, at least 2 chars.
+	if len(s) < 2 {
+		return false
+	}
+	for _, c := range s {
+		if c != '_' && (c < 'A' || c > 'Z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	// Exclude things that look like variable references.
+	return !strings.HasPrefix(s, "${") && !strings.HasPrefix(s, "$<")
+}

--- a/internal/formatter/rules/rule.go
+++ b/internal/formatter/rules/rule.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"github.com/donaldgifford/cmakefmt/internal/config"
+	"github.com/donaldgifford/cmakefmt/internal/parser"
+)
+
+// Rule is the interface that all formatting rules implement.
+// Adding a new rule is as simple as:
+//  1. Create a new file in this package.
+//  2. Implement the Rule interface.
+//  3. Register it in the registry via init().
+type Rule interface {
+	// Name returns the unique identifier for this rule (e.g., "indent", "command_case").
+	Name() string
+	// Description returns a human-readable description of what this rule does.
+	Description() string
+	// Apply transforms the AST node in place according to this rule.
+	Apply(node parser.Node, cfg *config.Config) error
+}
+
+// registry holds all registered rules.
+var registry []Rule
+
+// Register adds a rule to the global registry.
+// Call this from init() in each rule file.
+func Register(r Rule) {
+	registry = append(registry, r)
+}
+
+// All returns all registered rules.
+func All() []Rule {
+	return registry
+}
+
+// ByName returns a rule by its name, or nil if not found.
+func ByName(name string) Rule {
+	for _, r := range registry {
+		if r.Name() == name {
+			return r
+		}
+	}
+	return nil
+}
+
+// EnabledRules returns only the rules that are enabled in the given config.
+func EnabledRules(cfg *config.Config) []Rule {
+	var enabled []Rule
+	for _, r := range registry {
+		rc, exists := cfg.Rules[r.Name()]
+		if exists && !rc.IsEnabled() {
+			continue
+		}
+		enabled = append(enabled, r)
+	}
+	return enabled
+}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,0 +1,372 @@
+package lexer
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Lexer tokenizes CMake source code.
+type Lexer struct {
+	input  string
+	pos    int
+	line   int
+	col    int
+	tokens []Token
+}
+
+// New creates a new Lexer for the given input.
+func New(input string) *Lexer {
+	return &Lexer{
+		input: input,
+		line:  1,
+		col:   1,
+	}
+}
+
+// Tokenize processes the entire input and returns all tokens.
+func (l *Lexer) Tokenize() ([]Token, error) {
+	for l.pos < len(l.input) {
+		if err := l.next(); err != nil {
+			return nil, err
+		}
+	}
+	l.emit(TokenEOF, "")
+	return l.tokens, nil
+}
+
+func (l *Lexer) peek() byte {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	return l.input[l.pos]
+}
+
+func (l *Lexer) peekAt(offset int) byte {
+	idx := l.pos + offset
+	if idx >= len(l.input) {
+		return 0
+	}
+	return l.input[idx]
+}
+
+func (l *Lexer) advance() byte {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	ch := l.input[l.pos]
+	l.pos++
+	if ch == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	return ch
+}
+
+func (l *Lexer) emit(typ TokenType, value string) {
+	l.tokens = append(l.tokens, Token{
+		Type:  typ,
+		Value: value,
+		Line:  l.line,
+		Col:   l.col,
+	})
+}
+
+func (l *Lexer) emitAt(typ TokenType, value string, line, col int) {
+	l.tokens = append(l.tokens, Token{
+		Type:  typ,
+		Value: value,
+		Line:  line,
+		Col:   col,
+	})
+}
+
+func (l *Lexer) next() error {
+	ch := l.peek()
+
+	switch {
+	case ch == '\n':
+		line, col := l.line, l.col
+		l.advance()
+		l.emitAt(TokenNewline, "\n", line, col)
+	case ch == '\r' && l.peekAt(1) == '\n':
+		line, col := l.line, l.col
+		l.advance()
+		l.advance()
+		l.emitAt(TokenNewline, "\r\n", line, col)
+	case ch == '\r':
+		line, col := l.line, l.col
+		l.advance()
+		l.emitAt(TokenNewline, "\r", line, col)
+	case ch == ' ' || ch == '\t':
+		l.lexSpace()
+	case ch == '#':
+		return l.lexComment()
+	case ch == '(':
+		line, col := l.line, l.col
+		l.advance()
+		l.emitAt(TokenLeftParen, "(", line, col)
+	case ch == ')':
+		line, col := l.line, l.col
+		l.advance()
+		l.emitAt(TokenRightParen, ")", line, col)
+	case ch == '"':
+		return l.lexQuotedArg()
+	case ch == '[' && l.isBracketStart():
+		return l.lexBracketArg()
+	case isIdentStart(ch):
+		l.lexIdentifierOrUnquoted()
+	default:
+		l.lexUnquotedArg()
+	}
+	return nil
+}
+
+func (l *Lexer) lexSpace() {
+	line, col := l.line, l.col
+	start := l.pos
+	for l.pos < len(l.input) && (l.peek() == ' ' || l.peek() == '\t') {
+		l.advance()
+	}
+	l.emitAt(TokenSpace, l.input[start:l.pos], line, col)
+}
+
+func (l *Lexer) lexComment() error {
+	line, col := l.line, l.col
+	// Check for bracket comment: #[=*[
+	if l.peekAt(1) == '[' {
+		eqCount := 0
+		i := 2
+		for l.peekAt(i) == '=' {
+			eqCount++
+			i++
+		}
+		if l.peekAt(i) == '[' {
+			return l.lexBracketComment(eqCount, line, col)
+		}
+	}
+
+	// Line comment
+	start := l.pos
+	for l.pos < len(l.input) && l.peek() != '\n' && l.peek() != '\r' {
+		l.advance()
+	}
+	l.emitAt(TokenLineComment, l.input[start:l.pos], line, col)
+	return nil
+}
+
+func (l *Lexer) lexBracketComment(eqCount int, line, col int) error {
+	start := l.pos
+	// Skip #[=*[
+	l.advance() // #
+	l.advance() // [
+	for range eqCount {
+		l.advance() // =
+	}
+	l.advance() // [
+
+	closer := "]" + strings.Repeat("=", eqCount) + "]"
+	for l.pos < len(l.input) {
+		idx := strings.Index(l.input[l.pos:], closer)
+		if idx < 0 {
+			// Consume rest of input
+			for l.pos < len(l.input) {
+				l.advance()
+			}
+			l.emitAt(TokenBracketComment, l.input[start:l.pos], line, col)
+			return nil
+		}
+		// Advance to end of closer
+		for range idx + len(closer) {
+			l.advance()
+		}
+		l.emitAt(TokenBracketComment, l.input[start:l.pos], line, col)
+		return nil
+	}
+	l.emitAt(TokenBracketComment, l.input[start:l.pos], line, col)
+	return nil
+}
+
+func (l *Lexer) lexQuotedArg() error {
+	line, col := l.line, l.col
+	start := l.pos
+	l.advance() // opening "
+
+	for l.pos < len(l.input) {
+		ch := l.peek()
+		if ch == '\\' {
+			l.advance() // backslash
+			l.advance() // escaped char
+			continue
+		}
+		if ch == '"' {
+			l.advance() // closing "
+			l.emitAt(TokenQuotedArg, l.input[start:l.pos], line, col)
+			return nil
+		}
+		l.advance()
+	}
+	// Unterminated quoted arg — emit what we have
+	l.emitAt(TokenQuotedArg, l.input[start:l.pos], line, col)
+	return nil
+}
+
+func (l *Lexer) isBracketStart() bool {
+	i := 1
+	for l.peekAt(i) == '=' {
+		i++
+	}
+	return l.peekAt(i) == '['
+}
+
+func (l *Lexer) lexBracketArg() error {
+	line, col := l.line, l.col
+	start := l.pos
+	l.advance() // [
+	eqCount := 0
+	for l.peek() == '=' {
+		eqCount++
+		l.advance()
+	}
+	l.advance() // [
+
+	closer := "]" + strings.Repeat("=", eqCount) + "]"
+	for l.pos < len(l.input) {
+		idx := strings.Index(l.input[l.pos:], closer)
+		if idx < 0 {
+			for l.pos < len(l.input) {
+				l.advance()
+			}
+			l.emitAt(TokenBracketArg, l.input[start:l.pos], line, col)
+			return nil
+		}
+		for range idx + len(closer) {
+			l.advance()
+		}
+		l.emitAt(TokenBracketArg, l.input[start:l.pos], line, col)
+		return nil
+	}
+	l.emitAt(TokenBracketArg, l.input[start:l.pos], line, col)
+	return nil
+}
+
+func (l *Lexer) lexIdentifierOrUnquoted() {
+	line, col := l.line, l.col
+	start := l.pos
+
+	// First consume identifier-like chars.
+	for l.pos < len(l.input) && isIdentChar(l.peek()) {
+		l.advance()
+	}
+
+	// Check if what follows (skipping space) is '(' — if so, this is a command name.
+	saved := l.pos
+	for saved < len(l.input) && (l.input[saved] == ' ' || l.input[saved] == '\t') {
+		saved++
+	}
+	if saved < len(l.input) && l.input[saved] == '(' {
+		l.emitAt(TokenIdentifier, l.input[start:l.pos], line, col)
+		return
+	}
+
+	// Not a command — continue consuming as unquoted argument.
+	// Unquoted args can contain /, ., -, +, $, {, }, <, >, @, etc.
+	for l.pos < len(l.input) {
+		ch := l.peek()
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' ||
+			ch == '(' || ch == ')' || ch == '#' || ch == '"' {
+			break
+		}
+		l.advance()
+	}
+
+	l.emitAt(TokenUnquotedArg, l.input[start:l.pos], line, col)
+}
+
+func (l *Lexer) lexUnquotedArg() {
+	line, col := l.line, l.col
+	start := l.pos
+	for l.pos < len(l.input) {
+		ch := l.peek()
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' ||
+			ch == '(' || ch == ')' || ch == '#' || ch == '"' {
+			break
+		}
+		l.advance()
+	}
+	if l.pos > start {
+		l.emitAt(TokenUnquotedArg, l.input[start:l.pos], line, col)
+	}
+}
+
+func isIdentStart(ch byte) bool {
+	return ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+func isIdentChar(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+// IsKeyword returns true if the given string is a CMake keyword used in
+// command arguments (e.g., PUBLIC, PRIVATE, INTERFACE, REQUIRED, etc.).
+func IsKeyword(s string) bool {
+	upper := strings.ToUpper(s)
+	_, ok := cmakeKeywords[upper]
+	return ok
+}
+
+// IsBlockOpener returns true if the command name opens a block
+// (e.g., if, foreach, while, function, macro, block).
+func IsBlockOpener(cmd string) bool {
+	lower := strings.ToLower(cmd)
+	_, ok := blockOpeners[lower]
+	return ok
+}
+
+// IsBlockCloser returns true if the command name closes a block
+// (e.g., endif, endforeach, endwhile, endfunction, endmacro, endblock).
+func IsBlockCloser(cmd string) bool {
+	lower := strings.ToLower(cmd)
+	_, ok := blockClosers[lower]
+	return ok
+}
+
+// IsBlockMiddle returns true if the command is a mid-block keyword
+// (e.g., else, elseif).
+func IsBlockMiddle(cmd string) bool {
+	lower := strings.ToLower(cmd)
+	return lower == "else" || lower == "elseif"
+}
+
+// IsCMakeIdentifier returns true if the rune is valid in a CMake identifier.
+func IsCMakeIdentifier(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+var blockOpeners = map[string]bool{
+	"if": true, "foreach": true, "while": true,
+	"function": true, "macro": true, "block": true,
+}
+
+var blockClosers = map[string]bool{
+	"endif": true, "endforeach": true, "endwhile": true,
+	"endfunction": true, "endmacro": true, "endblock": true,
+}
+
+var cmakeKeywords = map[string]bool{
+	"PUBLIC": true, "PRIVATE": true, "INTERFACE": true,
+	"REQUIRED": true, "COMPONENTS": true, "OPTIONAL_COMPONENTS": true,
+	"CONFIG": true, "MODULE": true, "NO_MODULE": true,
+	"QUIET": true, "EXACT": true,
+	"DESTINATION": true, "RENAME": true, "PERMISSIONS": true,
+	"TARGETS": true, "FILES": true, "PROGRAMS": true, "DIRECTORY": true,
+	"EXPORT": true, "NAMESPACE": true, "FILE": true,
+	"PROPERTIES": true, "PROPERTY": true,
+	"IMPORTED": true, "GLOBAL": true, "ALIAS": true,
+	"STATIC": true, "SHARED": true, "MODULE_LIBRARY": true, "OBJECT": true,
+	"COMMAND": true, "DEPENDS": true, "WORKING_DIRECTORY": true,
+	"COMMENT": true, "VERBATIM": true,
+	"APPEND": true, "PARENT_SCOPE": true, "CACHE": true, "FORCE": true,
+	"BOOL": true, "STRING": true, "FILEPATH": true, "PATH": true, "INTERNAL": true,
+}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -1,0 +1,135 @@
+package lexer
+
+import (
+	"testing"
+)
+
+func TestTokenizeSimpleCommand(t *testing.T) {
+	input := `set(FOO "bar")`
+	lex := New(input)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []TokenType{
+		TokenIdentifier,  // set
+		TokenLeftParen,    // (
+		TokenUnquotedArg,  // FOO
+		TokenSpace,        // " "
+		TokenQuotedArg,    // "bar"
+		TokenRightParen,   // )
+		TokenEOF,
+	}
+
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(expected), len(tokens), tokens)
+	}
+
+	for i, tok := range tokens {
+		if tok.Type != expected[i] {
+			t.Errorf("token %d: expected %s, got %s (%q)", i, expected[i], tok.Type, tok.Value)
+		}
+	}
+}
+
+func TestTokenizeComment(t *testing.T) {
+	input := "# this is a comment\nset(X Y)\n"
+	lex := New(input)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tokens[0].Type != TokenLineComment {
+		t.Errorf("expected LineComment, got %s", tokens[0].Type)
+	}
+	if tokens[0].Value != "# this is a comment" {
+		t.Errorf("expected comment value, got %q", tokens[0].Value)
+	}
+}
+
+func TestTokenizeBracketArgument(t *testing.T) {
+	input := `set(X [=[hello world]=])`
+	lex := New(input)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the bracket arg token.
+	found := false
+	for _, tok := range tokens {
+		if tok.Type == TokenBracketArg {
+			found = true
+			if tok.Value != "[=[hello world]=]" {
+				t.Errorf("expected bracket arg value, got %q", tok.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("no bracket argument token found")
+	}
+}
+
+func TestTokenizeMultiLineCommand(t *testing.T) {
+	input := "target_link_libraries(\n  mylib\n  PUBLIC\n  fmt::fmt\n)\n"
+	lex := New(input)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tokens[0].Type != TokenIdentifier {
+		t.Errorf("expected Identifier, got %s", tokens[0].Type)
+	}
+	if tokens[0].Value != "target_link_libraries" {
+		t.Errorf("expected 'target_link_libraries', got %q", tokens[0].Value)
+	}
+}
+
+func TestIsBlockOpener(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"if", true},
+		{"IF", true},
+		{"foreach", true},
+		{"while", true},
+		{"function", true},
+		{"macro", true},
+		{"set", false},
+		{"endif", false},
+	}
+
+	for _, tt := range tests {
+		got := IsBlockOpener(tt.input)
+		if got != tt.want {
+			t.Errorf("IsBlockOpener(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsBlockCloser(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"endif", true},
+		{"ENDIF", true},
+		{"endforeach", true},
+		{"endwhile", true},
+		{"endfunction", true},
+		{"endmacro", true},
+		{"if", false},
+		{"set", false},
+	}
+
+	for _, tt := range tests {
+		got := IsBlockCloser(tt.input)
+		if got != tt.want {
+			t.Errorf("IsBlockCloser(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/lexer/token.go
+++ b/internal/lexer/token.go
@@ -1,0 +1,64 @@
+package lexer
+
+import "fmt"
+
+// TokenType represents the type of a lexical token.
+type TokenType int
+
+const (
+	// TokenEOF indicates end of input.
+	TokenEOF TokenType = iota
+	// TokenNewline is a newline character (or \r\n).
+	TokenNewline
+	// TokenSpace is horizontal whitespace (spaces/tabs, not newlines).
+	TokenSpace
+	// TokenIdentifier is a command name (e.g., "set", "if", "target_link_libraries").
+	TokenIdentifier
+	// TokenLeftParen is '('.
+	TokenLeftParen
+	// TokenRightParen is ')'.
+	TokenRightParen
+	// TokenQuotedArg is a quoted argument including quotes (e.g., `"hello world"`).
+	TokenQuotedArg
+	// TokenUnquotedArg is an unquoted argument (e.g., `foo`, `${VAR}`, `$<GENEX>`).
+	TokenUnquotedArg
+	// TokenBracketArg is a bracket argument (e.g., `[=[content]=]`).
+	TokenBracketArg
+	// TokenLineComment is a line comment (e.g., `# this is a comment`).
+	TokenLineComment
+	// TokenBracketComment is a bracket comment (e.g., `#[=[comment]=]`).
+	TokenBracketComment
+)
+
+var tokenNames = map[TokenType]string{
+	TokenEOF:            "EOF",
+	TokenNewline:        "Newline",
+	TokenSpace:          "Space",
+	TokenIdentifier:     "Identifier",
+	TokenLeftParen:      "LeftParen",
+	TokenRightParen:     "RightParen",
+	TokenQuotedArg:      "QuotedArg",
+	TokenUnquotedArg:    "UnquotedArg",
+	TokenBracketArg:     "BracketArg",
+	TokenLineComment:    "LineComment",
+	TokenBracketComment: "BracketComment",
+}
+
+func (t TokenType) String() string {
+	if name, ok := tokenNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("TokenType(%d)", int(t))
+}
+
+// Token represents a lexical token with its position in the source.
+type Token struct {
+	Type  TokenType
+	Value string
+	Line  int
+	Col   int
+}
+
+func (t Token) String() string {
+	return fmt.Sprintf("%s(%q) at %d:%d", t.Type, t.Value, t.Line, t.Col)
+}

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -1,0 +1,71 @@
+package parser
+
+import "github.com/donaldgifford/cmakefmt/internal/lexer"
+
+// Node is the interface all AST nodes implement.
+type Node interface {
+	nodeType() string
+}
+
+// File is the root node of a CMake file.
+type File struct {
+	Elements []Node
+}
+
+func (f *File) nodeType() string { return "File" }
+
+// CommandInvocation represents a command call like `set(FOO "bar")`.
+type CommandInvocation struct {
+	Name      string
+	NameToken lexer.Token
+	Arguments []Argument
+	// LeadingSpace is whitespace before the command name on the same line.
+	LeadingSpace string
+	// TrailingComment is an inline comment after the closing paren.
+	TrailingComment string
+	Line            int
+}
+
+func (c *CommandInvocation) nodeType() string { return "Command" }
+
+// Argument represents a single argument to a command.
+type Argument struct {
+	Token lexer.Token
+	// Nested arguments (for parenthesized groups).
+	Children []Argument
+}
+
+// Comment represents a standalone comment (not attached to a command).
+type Comment struct {
+	Value string
+	Line  int
+	// LeadingSpace is the whitespace before the comment.
+	LeadingSpace string
+}
+
+func (c *Comment) nodeType() string { return "Comment" }
+
+// BlankLine represents one or more consecutive blank lines.
+type BlankLine struct {
+	Count int
+	Line  int
+}
+
+func (b *BlankLine) nodeType() string { return "BlankLine" }
+
+// BlockNode represents an indented block (if/endif, foreach/endforeach, etc.).
+type BlockNode struct {
+	Opener *CommandInvocation
+	Body   []Node
+	Closer *CommandInvocation
+	// Middles holds elseif/else commands and their body sections.
+	Middles []BlockMiddle
+}
+
+func (b *BlockNode) nodeType() string { return "Block" }
+
+// BlockMiddle represents an else/elseif and the body following it.
+type BlockMiddle struct {
+	Command *CommandInvocation
+	Body    []Node
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,246 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/donaldgifford/cmakefmt/internal/lexer"
+)
+
+// Parser builds an AST from a stream of tokens.
+type Parser struct {
+	tokens []lexer.Token
+	pos    int
+}
+
+// New creates a new Parser for the given tokens.
+func New(tokens []lexer.Token) *Parser {
+	return &Parser{tokens: tokens}
+}
+
+// Parse processes all tokens and returns the root File node.
+func (p *Parser) Parse() (*File, error) {
+	elements, err := p.parseElements(false)
+	if err != nil {
+		return nil, err
+	}
+	return &File{Elements: elements}, nil
+}
+
+func (p *Parser) peek() lexer.Token {
+	if p.pos >= len(p.tokens) {
+		return lexer.Token{Type: lexer.TokenEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *Parser) advance() lexer.Token {
+	tok := p.peek()
+	if p.pos < len(p.tokens) {
+		p.pos++
+	}
+	return tok
+}
+
+func (p *Parser) parseElements(inBlock bool) ([]Node, error) {
+	var elements []Node
+	blankCount := 0
+
+	for {
+		tok := p.peek()
+
+		switch tok.Type {
+		case lexer.TokenEOF:
+			if blankCount > 0 {
+				elements = append(elements, &BlankLine{Count: blankCount, Line: tok.Line})
+			}
+			return elements, nil
+
+		case lexer.TokenNewline:
+			p.advance()
+			blankCount++
+			if blankCount > 1 {
+				// Will emit a BlankLine when we hit the next non-blank token.
+			}
+			continue
+
+		case lexer.TokenSpace:
+			// Consume leading space, might be needed for commands.
+			p.advance()
+			continue
+
+		case lexer.TokenLineComment, lexer.TokenBracketComment:
+			if blankCount > 1 {
+				elements = append(elements, &BlankLine{Count: blankCount - 1, Line: tok.Line})
+			}
+			blankCount = 0
+			comment := p.parseComment()
+			elements = append(elements, comment)
+
+		case lexer.TokenIdentifier:
+			if blankCount > 1 {
+				elements = append(elements, &BlankLine{Count: blankCount - 1, Line: tok.Line})
+			}
+			blankCount = 0
+
+			// Check if this is a block closer or middle — if so, return to parent.
+			if inBlock && (lexer.IsBlockCloser(tok.Value) || lexer.IsBlockMiddle(tok.Value)) {
+				return elements, nil
+			}
+
+			cmd, err := p.parseCommand()
+			if err != nil {
+				return nil, err
+			}
+
+			// If the command opens a block, parse the block body.
+			if lexer.IsBlockOpener(cmd.Name) {
+				block, err := p.parseBlock(cmd)
+				if err != nil {
+					return nil, err
+				}
+				elements = append(elements, block)
+			} else {
+				elements = append(elements, cmd)
+			}
+
+		default:
+			// Skip unexpected tokens.
+			p.advance()
+			blankCount = 0
+		}
+	}
+}
+
+func (p *Parser) parseComment() *Comment {
+	tok := p.advance()
+	return &Comment{
+		Value: tok.Value,
+		Line:  tok.Line,
+	}
+}
+
+func (p *Parser) parseCommand() (*CommandInvocation, error) {
+	nameTok := p.advance() // Identifier
+	cmd := &CommandInvocation{
+		Name:      nameTok.Value,
+		NameToken: nameTok,
+		Line:      nameTok.Line,
+	}
+
+	// Skip whitespace between name and '('.
+	p.skipSpaceAndNewlines()
+
+	if p.peek().Type != lexer.TokenLeftParen {
+		return nil, fmt.Errorf("expected '(' after command %q at line %d, got %s",
+			cmd.Name, nameTok.Line, p.peek().Type)
+	}
+	p.advance() // consume '('
+
+	args, err := p.parseArguments()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Arguments = args
+
+	if p.peek().Type != lexer.TokenRightParen {
+		return nil, fmt.Errorf("expected ')' to close command %q at line %d, got %s",
+			cmd.Name, nameTok.Line, p.peek().Type)
+	}
+	p.advance() // consume ')'
+
+	// Check for trailing inline comment.
+	p.skipSpaces()
+	if p.peek().Type == lexer.TokenLineComment {
+		cmd.TrailingComment = p.advance().Value
+	}
+
+	return cmd, nil
+}
+
+func (p *Parser) parseArguments() ([]Argument, error) {
+	var args []Argument
+
+	for {
+		p.skipSpaceAndNewlines()
+		tok := p.peek()
+
+		switch tok.Type {
+		case lexer.TokenRightParen, lexer.TokenEOF:
+			return args, nil
+		case lexer.TokenLeftParen:
+			p.advance()
+			children, err := p.parseArguments()
+			if err != nil {
+				return nil, err
+			}
+			if p.peek().Type == lexer.TokenRightParen {
+				p.advance()
+			}
+			args = append(args, Argument{
+				Token:    tok,
+				Children: children,
+			})
+		case lexer.TokenQuotedArg, lexer.TokenUnquotedArg, lexer.TokenBracketArg:
+			args = append(args, Argument{Token: p.advance()})
+		case lexer.TokenLineComment:
+			// Comments inside argument lists are preserved as arguments.
+			args = append(args, Argument{Token: p.advance()})
+		default:
+			p.advance() // skip unexpected
+		}
+	}
+}
+
+func (p *Parser) parseBlock(opener *CommandInvocation) (*BlockNode, error) {
+	block := &BlockNode{Opener: opener}
+
+	body, err := p.parseElements(true)
+	if err != nil {
+		return nil, err
+	}
+	block.Body = body
+
+	// Handle else/elseif middles.
+	for p.peek().Type == lexer.TokenIdentifier && lexer.IsBlockMiddle(p.peek().Value) {
+		mid, err := p.parseCommand()
+		if err != nil {
+			return nil, err
+		}
+		midBody, err := p.parseElements(true)
+		if err != nil {
+			return nil, err
+		}
+		block.Middles = append(block.Middles, BlockMiddle{
+			Command: mid,
+			Body:    midBody,
+		})
+	}
+
+	// Parse the closer.
+	if p.peek().Type == lexer.TokenIdentifier && lexer.IsBlockCloser(p.peek().Value) {
+		closer, err := p.parseCommand()
+		if err != nil {
+			return nil, err
+		}
+		block.Closer = closer
+	}
+
+	return block, nil
+}
+
+func (p *Parser) skipSpaces() {
+	for p.peek().Type == lexer.TokenSpace {
+		p.advance()
+	}
+}
+
+func (p *Parser) skipSpaceAndNewlines() {
+	for {
+		t := p.peek().Type
+		if t == lexer.TokenSpace || t == lexer.TokenNewline {
+			p.advance()
+			continue
+		}
+		break
+	}
+}

--- a/scripts/labels.sh
+++ b/scripts/labels.sh
@@ -44,6 +44,17 @@ declare -A LABEL_COLORS=(
   ["minor"]="0E8A16"        # Green - feature
   ["patch"]="FEF2C0"        # Yellow - fix
   ["dont-release"]="D4C5F9" # Lavender - skip
+
+  # Severity labels
+  ["severity: critical"]="B60205" # Dark red - critical
+  ["severity: high"]="D93F0B"     # Red-orange - high
+  ["severity: medium"]="FBCA04"   # Yellow - medium
+  ["severity: low"]="0E8A16"      # Green - low
+
+  # Category labels
+  ["chore"]="C2E0C6"        # Light green - maintenance
+  ["security"]="D73A4A"     # Red - security
+  ["code-quality"]="BFD4F2" # Light blue - code quality
 )
 
 declare -A LABEL_DESCRIPTIONS=(
@@ -62,6 +73,17 @@ declare -A LABEL_DESCRIPTIONS=(
   ["minor"]="New features - increment minor version (0.x.0)"
   ["patch"]="Bug fixes - increment patch version (0.0.x)"
   ["dont-release"]="No release needed for this PR"
+
+  # Severity labels
+  ["severity: critical"]="Urgent issue requiring immediate attention"
+  ["severity: high"]="Important issue to address soon"
+  ["severity: medium"]="Moderate issue to address in normal workflow"
+  ["severity: low"]="Minor issue or improvement"
+
+  # Category labels
+  ["chore"]="Maintenance, refactoring, or tooling changes"
+  ["security"]="Security-related issue or fix"
+  ["code-quality"]="Code quality improvement or technical debt"
 )
 
 # Script directory and repo root
@@ -161,7 +183,7 @@ label_exists() {
   local label="$1"
   local existing_labels="$2"
 
-  echo "$existing_labels" | grep -q "^${label}$"
+  echo "$existing_labels" | grep -qxF "$label"
 }
 
 create_label() {
@@ -255,9 +277,16 @@ main() {
   pr_labels=$(extract_labels_from_pr_workflow "$PR_LABELS_FILE")
   log_info "Found $(echo "$pr_labels" | wc -l | tr -d ' ') labels in pr-labels.yml"
 
+  # Severity labels are manual-only (not auto-applied by labeler)
+  local severity_labels="severity: critical
+severity: high
+severity: medium
+severity: low"
+  log_info "Found 4 severity labels defined in script"
+
   # Combine and deduplicate
   local all_labels
-  all_labels=$(echo -e "${labeler_labels}\n${pr_labels}" | sort -u)
+  all_labels=$(echo -e "${labeler_labels}\n${pr_labels}\n${severity_labels}" | sort -u)
   local total_labels
   total_labels=$(echo "$all_labels" | wc -l | tr -d ' ')
 

--- a/testdata/unformatted.cmake
+++ b/testdata/unformatted.cmake
@@ -1,0 +1,32 @@
+CMAKE_MINIMUM_REQUIRED( VERSION  3.20 )
+
+PROJECT(  myproject   VERSION 1.0.0
+    LANGUAGES CXX )
+
+
+SET(SOURCES
+  src/main.cpp
+  src/utils.cpp
+  src/config.cpp
+        )
+
+ADD_EXECUTABLE( myproject ${SOURCES} )
+
+TARGET_LINK_LIBRARIES(myproject
+    public  fmt::fmt
+    private  spdlog::spdlog
+)
+
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    TARGET_COMPILE_OPTIONS(myproject private -Wall -Wextra -Wpedantic)
+ELSE()
+  MESSAGE(STATUS "Release build")
+ENDIF()
+
+# Find dependencies
+FIND_PACKAGE(fmt required)
+FIND_PACKAGE(spdlog required CONFIG)
+
+INSTALL(targets myproject
+    destination ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
## Summary

- Full CMake formatter with lexer, parser, AST, and rule-based formatting engine
- CLI with stdin/stdout mode (editor integration), in-place formatting, check mode, and diff output
- Config file support (`.cmakefmt`) with JSON and YAML-like formats, directory walk discovery
- Extensible rule system with `command_case` and `keyword_case` rules
- GitHub labels for severity (critical/high/medium/low) and categories (chore/security/code-quality)
- Labeler rules for auto-applying chore, security, and code-quality labels on PRs
- Project tooling: Makefile, goreleaser with ldflags, CLAUDE.md, updated README

## Test plan

- [x] `go test -race ./...` passes (lexer + formatter tests)
- [x] `go vet ./...` clean
- [ ] Run `make build && bin/cmakefmt -i testdata/` to verify end-to-end formatting
- [ ] Run `scripts/labels.sh --dry-run` to verify label creation logic
- [ ] Test stdin/stdout mode: `echo 'SET(FOO bar)' | bin/cmakefmt`
- [ ] Test check mode: `bin/cmakefmt -check testdata/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)